### PR TITLE
feat: cache konan files to speed up the compilation time in kt-MP projects

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -138,6 +138,7 @@ runs:
           ~/.gradle/caches
           ~/.gradle/wrapper
           ~/.gradle/jdks
+          ~/.konan
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-


### PR DESCRIPTION
This PR cache the `konan` files according to the documentation (https://kotlinlang.org/docs/native-improving-compilation-time.html#general-recommendations) to speed up the compilation time in kt-MP projects