### PR TITLE
fix: use mavenCentral naming for gradle properties

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -188,9 +188,9 @@ runs:
         NPM_TOKEN: ${{ inputs.npm-token }}
         # Gradle-specific exports, see: 
         # https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties
-        ORG_GRADLE_PROJECT_mavenRepo: ${{ inputs.maven-central-repo }}
-        ORG_GRADLE_PROJECT_mavenUsername: ${{ inputs.maven-central-username }}
-        ORG_GRADLE_PROJECT_mavenPassword: ${{ inputs.maven-central-password }}  
+        ORG_GRADLE_PROJECT_mavenCentralRepo: ${{ inputs.maven-central-repo }}
+        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ inputs.maven-central-username }}
+        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ inputs.maven-central-password }}  
         ORG_GRADLE_PROJECT_signingKey: ${{ inputs.signing-key }}
         ORG_GRADLE_PROJECT_signingPassword: ${{ inputs.signing-password }}
         ORG_GRADLE_PROJECT_npmRepo: ${{ inputs.npm-repo }}


### PR DESCRIPTION
Parameters `maven-central-X` used to set:
1. environment variables `MAVEN_CENTRAL_X`
2. Gradle properties `mavenX`

Item 1 is __un__affected, whereas item 2 was just for me.
I admit I was an asshole, and I should have complied to your naming convention since the very beginning.

Now that I'm using `publish-on-central` as well, I need to comply to your naming convention, hence this PR :)