### PR TITLE
Parametric retry mechanism for all stages (from pre-build to clean)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -152,22 +152,22 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gradle-
     - name: Restore pip dependencies
-      working-directory: ${{ inputs.working-directory }}
-      run: pip install -r ${{ github.action_path }}/requirements.txt
+      working-directory: ${{ github.action_path }}
+      run: pip3 install -r requirements.txt
       shell: bash
     - name: Pre-build
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         echo "::group::Pre-build"
-        python ${{ github.action_path }}/retry.py ${{ inputs.pre-build-command }}
+        python3 ${{ github.action_path }}/retry.py ${{ inputs.pre-build-command }}
         echo "::endgroup::"
     - name: Build
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::group::Build"
-        python ${{ github.action_path }}/retry.py ${{ inputs.build-command }}
+        python3 ${{ github.action_path }}/retry.py ${{ inputs.build-command }}
         echo "::endgroup::"
       env:
         RETRY_TIME: ${{ inputs.retry-delay }}
@@ -177,7 +177,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::group::Check"
-        python ${{ github.action_path }}/retry.py ${{ inputs.check-command }}
+        python3 ${{ github.action_path }}/retry.py ${{ inputs.check-command }}
         echo "::endgroup::"
       env:
         RETRY_TIME: ${{ inputs.retry-delay }}
@@ -218,14 +218,14 @@ runs:
         ORG_GRADLE_PROJECT_npmToken: ${{ inputs.npm-token }}
       run: |
         echo "::group::Deploy"
-        python ${{ github.action_path }}/retry.py ${{ inputs.deploy-command }}
+        python3 ${{ github.action_path }}/retry.py ${{ inputs.deploy-command }}
         echo "::endgroup::"
     - name: Cleanup
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         echo "::group::Cleanup"
-        python ${{ github.action_path }}/retry.py ${{ inputs.clean-command }}
+        python3 ${{ github.action_path }}/retry.py ${{ inputs.clean-command }}
         echo "::endgroup::"
       env:
         RETRY_TIME: ${{ inputs.retry-delay }}

--- a/action.yml
+++ b/action.yml
@@ -110,9 +110,20 @@ inputs:
   npm-token:
     description: 'Authorization token for the NPM registry of choice, it will be exposed in the deployment step as the environment variable ORG_GRADLE_PROJECT_npmToken'
     required: false
+  max-attempts:
+    description: 'Maximum amount of attempts when retrying a stage'
+    required: false
+    default: '1'
+  retry-delay:
+    description: 'Time to be waited among any two attempts'
+    required: false
+    default: '1m'
 
 runs:
   using: composite
+  env:
+    RETRY_TIME: ${{ inputs.retry-delay }}
+    MAX_RETRIES: ${{ inputs.max-attempts }}
   steps:
     - name: Validate the Gradle Wrapper
       if: inputs.should-validate-wrapper == 'true'
@@ -143,26 +154,28 @@ runs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
+    - name: Restore pip dependencies
+      run: pip install -r ${{ github.action_path }}/requirements.txt
     - name: Pre-build
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         echo "::group::Pre-build"
-        ${{ inputs.pre-build-command }}
+        python ${{ github.action_path }}/retry.py ${{ inputs.pre-build-command }}
         echo "::endgroup::"
     - name: Build
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::group::Build"
-        ${{ inputs.build-command }}
+        python ${{ github.action_path }}/retry.py ${{ inputs.build-command }}
         echo "::endgroup::"
     - name: Check
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::group::Check"
-        ${{ inputs.check-command }}
+        python ${{ github.action_path }}/retry.py ${{ inputs.check-command }}
         echo "::endgroup::"
     - name: CodeCov
       if: inputs.should-run-codecov == 'true'
@@ -198,14 +211,14 @@ runs:
         ORG_GRADLE_PROJECT_npmToken: ${{ inputs.npm-token }}
       run: |
         echo "::group::Deploy"
-        ${{ inputs.deploy-command }}
+        python ${{ github.action_path }}/retry.py ${{ inputs.deploy-command }}
         echo "::endgroup::"
     - name: Cleanup
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         echo "::group::Cleanup"
-        ${{ inputs.clean-command }}
+        python ${{ github.action_path }}/retry.py ${{ inputs.clean-command }}
         echo "::endgroup::"
     - name: Turn off the Gradle Daemon
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -121,9 +121,6 @@ inputs:
 
 runs:
   using: composite
-  env:
-    RETRY_TIME: ${{ inputs.retry-delay }}
-    MAX_RETRIES: ${{ inputs.max-attempts }}
   steps:
     - name: Validate the Gradle Wrapper
       if: inputs.should-validate-wrapper == 'true'
@@ -155,7 +152,9 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gradle-
     - name: Restore pip dependencies
+      working-directory: ${{ inputs.working-directory }}
       run: pip install -r ${{ github.action_path }}/requirements.txt
+      shell: bash
     - name: Pre-build
       working-directory: ${{ inputs.working-directory }}
       shell: bash
@@ -170,6 +169,9 @@ runs:
         echo "::group::Build"
         python ${{ github.action_path }}/retry.py ${{ inputs.build-command }}
         echo "::endgroup::"
+      env:
+        RETRY_TIME: ${{ inputs.retry-delay }}
+        MAX_RETRIES: ${{ inputs.max-attempts }}
     - name: Check
       shell: bash
       working-directory: ${{ inputs.working-directory }}
@@ -177,6 +179,9 @@ runs:
         echo "::group::Check"
         python ${{ github.action_path }}/retry.py ${{ inputs.check-command }}
         echo "::endgroup::"
+      env:
+        RETRY_TIME: ${{ inputs.retry-delay }}
+        MAX_RETRIES: ${{ inputs.max-attempts }}
     - name: CodeCov
       if: inputs.should-run-codecov == 'true'
       uses: codecov/codecov-action@v3.1.4
@@ -187,6 +192,8 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       env:
+        RETRY_TIME: ${{ inputs.retry-delay }}
+        MAX_RETRIES: ${{ inputs.max-attempts }}
         CUSTOM_SECRET_0: ${{ inputs.custom-secret-0 }}
         CUSTOM_SECRET_1: ${{ inputs.custom-secret-1 }}
         CUSTOM_SECRET_2: ${{ inputs.custom-secret-2 }}
@@ -220,6 +227,9 @@ runs:
         echo "::group::Cleanup"
         python ${{ github.action_path }}/retry.py ${{ inputs.clean-command }}
         echo "::endgroup::"
+      env:
+        RETRY_TIME: ${{ inputs.retry-delay }}
+        MAX_RETRIES: ${{ inputs.max-attempts }}
     - name: Turn off the Gradle Daemon
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/action.yml
+++ b/action.yml
@@ -138,6 +138,7 @@ runs:
           ~/.gradle/caches
           ~/.gradle/wrapper
           ~/.gradle/jdks
+          ~/.gradle/nodejs
           ~/.konan
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |

--- a/action.yml
+++ b/action.yml
@@ -155,27 +155,24 @@ runs:
       working-directory: ${{ github.action_path }}
       run: pip3 install -r requirements.txt
       shell: bash
-    - name: Set retry script path Unix
-      if: ${{ runner.os != 'Windows' }}
-      run: echo "RETRY_SCRIPT=${{ github.action_path }}/retry.py" >> GITHUB_ENV
-      shell: bash
-    - name: Set retry script path Unix
-      if: ${{ runner.os == 'Windows' }}
-      run: echo 'RETRY_SCRIPT=${{ github.action_path }}\retry.py' >> GITHUB_ENV
+    - name: Set retry script path 
+      working-directory: ${{ github.action_path }}
+      id: find-retry-script-path
+      run: echo "path=$(pwd)/retry.py" >> $GITHUB_OUTPUT
       shell: bash
     - name: Pre-build
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         echo "::group::Pre-build"
-        python3 ${{ env.RETRY_SCRIPT }} ${{ inputs.pre-build-command }}
+        python3 ${{ steps.find-retry-script-path.outputs.path }} ${{ inputs.pre-build-command }}
         echo "::endgroup::"
     - name: Build
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::group::Build"
-        python3 ${{ env.RETRY_SCRIPT }} ${{ inputs.build-command }}
+        python3 ${{ steps.find-retry-script-path.outputs.path }} ${{ inputs.build-command }}
         echo "::endgroup::"
       env:
         RETRY_TIME: ${{ inputs.retry-delay }}
@@ -185,7 +182,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::group::Check"
-        python3 ${{ env.RETRY_SCRIPT }} ${{ inputs.check-command }}
+        python3 ${{ steps.find-retry-script-path.outputs.path }} ${{ inputs.check-command }}
         echo "::endgroup::"
       env:
         RETRY_TIME: ${{ inputs.retry-delay }}
@@ -226,14 +223,14 @@ runs:
         ORG_GRADLE_PROJECT_npmToken: ${{ inputs.npm-token }}
       run: |
         echo "::group::Deploy"
-        python3 ${{ env.RETRY_SCRIPT }} ${{ inputs.deploy-command }}
+        python3 ${{ steps.find-retry-script-path.outputs.path }} ${{ inputs.deploy-command }}
         echo "::endgroup::"
     - name: Cleanup
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         echo "::group::Cleanup"
-        python3 ${{ env.RETRY_SCRIPT }} ${{ inputs.clean-command }}
+        python3 ${{ steps.find-retry-script-path.outputs.path }} ${{ inputs.clean-command }}
         echo "::endgroup::"
       env:
         RETRY_TIME: ${{ inputs.retry-delay }}

--- a/action.yml
+++ b/action.yml
@@ -155,19 +155,27 @@ runs:
       working-directory: ${{ github.action_path }}
       run: pip3 install -r requirements.txt
       shell: bash
+    - name: Set retry script path Unix
+      if: ${{ runner.os != 'Windows' }}
+      run: echo "RETRY_SCRIPT=${{ github.action_path }}/retry.py" >> GITHUB_ENV
+      shell: bash
+    - name: Set retry script path Unix
+      if: ${{ runner.os == 'Windows' }}
+      run: echo 'RETRY_SCRIPT=${{ github.action_path }}\retry.py' >> GITHUB_ENV
+      shell: bash
     - name: Pre-build
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         echo "::group::Pre-build"
-        python3 ${{ github.action_path }}/retry.py ${{ inputs.pre-build-command }}
+        python3 ${{ env.RETRY_SCRIPT }} ${{ inputs.pre-build-command }}
         echo "::endgroup::"
     - name: Build
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::group::Build"
-        python3 ${{ github.action_path }}/retry.py ${{ inputs.build-command }}
+        python3 ${{ env.RETRY_SCRIPT }} ${{ inputs.build-command }}
         echo "::endgroup::"
       env:
         RETRY_TIME: ${{ inputs.retry-delay }}
@@ -177,7 +185,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::group::Check"
-        python3 ${{ github.action_path }}/retry.py ${{ inputs.check-command }}
+        python3 ${{ env.RETRY_SCRIPT }} ${{ inputs.check-command }}
         echo "::endgroup::"
       env:
         RETRY_TIME: ${{ inputs.retry-delay }}
@@ -218,14 +226,14 @@ runs:
         ORG_GRADLE_PROJECT_npmToken: ${{ inputs.npm-token }}
       run: |
         echo "::group::Deploy"
-        python3 ${{ github.action_path }}/retry.py ${{ inputs.deploy-command }}
+        python3 ${{ env.RETRY_SCRIPT }} ${{ inputs.deploy-command }}
         echo "::endgroup::"
     - name: Cleanup
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         echo "::group::Cleanup"
-        python3 ${{ github.action_path }}/retry.py ${{ inputs.clean-command }}
+        python3 ${{ env.RETRY_SCRIPT }} ${{ inputs.clean-command }}
         echo "::endgroup::"
       env:
         RETRY_TIME: ${{ inputs.retry-delay }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pytimeparse==1.1.8

--- a/retry.py
+++ b/retry.py
@@ -1,0 +1,47 @@
+import os
+from pytimeparse.timeparse import timeparse
+import sys
+import time
+
+
+CMD = " ".join(sys.argv[1:])
+RETRY_TIME = os.environ.get("RETRY_TIME", "1m")
+DT = timeparse(RETRY_TIME)
+MAX = int(os.environ.get("MAX_RETRIES", "3"))
+
+if not CMD:
+    raise ValueError("Invalid command: " + CMD)
+
+
+def sleep(seconds):
+    for x in range(0, seconds):
+        time.sleep(1)
+        print(f"Slept for {x} seconds")
+
+
+def log(*args):
+    args = ("===",) + args + ("===",)
+    print(*args)
+
+
+def attempt():
+    print(CMD)
+    status = os.system(CMD)
+    status = os.waitstatus_to_exitcode(status)
+    if status == 0:
+        log(f"Done")
+        sys.exit(0)
+    return status
+
+
+if __name__ == "__main__":
+    status = 0
+    for i in range(1, MAX):
+        env = dict(os.environ, ATTEMPT=i)
+        log(f"Attempt {i}/{MAX}")
+        status = attempt()
+        log(f"Failed attempt {i}/{MAX}, sleeping for {RETRY_TIME}")
+        sleep(DT) 
+    status = attempt()
+    log(f"Failed last attempt {MAX}/{MAX}, returning {status}")
+    sys.exit(status)

--- a/retry.py
+++ b/retry.py
@@ -4,6 +4,9 @@ import sys
 import time
 
 
+WIN = any(platform in sys.platform for platform in { 'win32', 'cygwin' }) or (os.name == 'nt')
+
+
 CMD = " ".join(sys.argv[1:])
 RETRY_TIME = os.environ.get("RETRY_TIME", "1m")
 DT = timeparse(RETRY_TIME)
@@ -26,7 +29,7 @@ def log(*args):
 
 def attempt():
     cmd = CMD
-    if "win" in sys.platform:
+    if WIN:
         cmd = "bash -c " + cmd
     print(cmd)
     status = os.system(cmd)

--- a/retry.py
+++ b/retry.py
@@ -25,8 +25,11 @@ def log(*args):
 
 
 def attempt():
-    print(CMD)
-    status = os.system(CMD)
+    cmd = CMD
+    if "win" in sys.platform:
+        cmd = "bash -c " + cmd
+    print(cmd)
+    status = os.system(cmd)
     status = os.waitstatus_to_exitcode(status)
     if status == 0:
         log(f"Done")

--- a/retry.py
+++ b/retry.py
@@ -5,10 +5,13 @@ import time
 import subprocess
 
 
+WIN = any(platform in sys.platform for platform in { 'win32', 'cygwin' }) or (os.name == 'nt')
+BASH = "C:\\Program Files\\Git\\bin\\bash.exe" if WIN else "bash"
 CMD = " ".join(sys.argv[1:])
 RETRY_TIME = os.environ.get("RETRY_TIME", "1m")
 DT = timeparse(RETRY_TIME)
 MAX = int(os.environ.get("MAX_RETRIES", "3"))
+
 
 if not CMD:
     raise ValueError("Invalid command: " + CMD)
@@ -27,7 +30,7 @@ def log(*args):
 
 def attempt():
     print(CMD)
-    status = subprocess.call(["bash", "-c", CMD])
+    status = subprocess.call([BASH, "-c", CMD])
     if status == 0:
         log(f"Done")
         sys.exit(0)

--- a/retry.py
+++ b/retry.py
@@ -2,9 +2,7 @@ import os
 from pytimeparse.timeparse import timeparse
 import sys
 import time
-
-
-WIN = any(platform in sys.platform for platform in { 'win32', 'cygwin' }) or (os.name == 'nt')
+import subprocess
 
 
 CMD = " ".join(sys.argv[1:])
@@ -28,12 +26,8 @@ def log(*args):
 
 
 def attempt():
-    cmd = CMD
-    if WIN:
-        cmd = "bash -c " + cmd
-    print(cmd)
-    status = os.system(cmd)
-    status = os.waitstatus_to_exitcode(status)
+    print(CMD)
+    status = subprocess.call(["bash", "-c", CMD])
     if status == 0:
         log(f"Done")
         sys.exit(0)


### PR DESCRIPTION
The action now accepts two more __optional__ parameters:
- `max-attempts` (default: `1`) which dictates how many times each stage should be retried before considering it failed
- `retry-delay` (default: `1m`, i.e. 1 minute) which dictates how much time should be waited before retrying with any given stage
    + this parameter's value is parsed via [`pytimeparse`](https://pypi.org/project/pytimeparse/), to give users flexibility in defining delays

So, the semantics of the action is now as follows:
- whenever executing `pre-build-command`, `build-command`, `check-command`, or `clean-command` (generically denoted as `COMMAND` in the following):
    -  for `ATTEMPT` in `1 .. $max-attempts`:
        1. `export $ATTEMPT`
        2. `bash -c $COMMAND`
        3. if the result of the last command is 0, return 0
        4. otherwise, unless it's the last attempt, sleep for `$retry-delay` seconds

Caveats:
- the `ATTEMPT` environment variable contains the current attempt number: it can be read by the build script to do stuff (e.g. tagging the build scan accordingly)
- while sleeping, one line will be logged each second, reporting the elapsed time so far